### PR TITLE
fix(translate): MessageID show ID

### DIFF
--- a/src/languages/en_US/strings.json
+++ b/src/languages/en_US/strings.json
@@ -33,7 +33,7 @@
 	"FALSE": "false",
 	"ON": "on",
 	"OFF": "off",
-	"MESSAGE_ID": "Message ID",
+	"MESSAGE_ID": "**Message ID:** {{id}}",
 	"MESSAGE_EDITED": "📝 Message edited",
 	"CHANNEL": "**Channel:** {{channel}}",
 	"XP_LOST": "User has lost {{amount}} XP.",


### PR DESCRIPTION
RN the `message edited` log message does not show the ID this PR changes that